### PR TITLE
Revert "Duplicate install of tidyverse"

### DIFF
--- a/.github/workflows/deploy-bookdown.yml
+++ b/.github/workflows/deploy-bookdown.yml
@@ -25,7 +25,7 @@ jobs:
       #     restore-keys: ${{ runner.os }}-r-
 
       - name: Install dependencies
-        run: Rscript -e 'install.packages(c("bookdown", "gridExtra"))'
+        run: Rscript -e 'install.packages(c("bookdown", "tidyverse", "gridExtra"))'
 
       - name: Render Book HTML for GH Pages
         run: |


### PR DESCRIPTION
This reverts commit 297efeed49fb5787ef69d9def2235bf5e13f00ed. Tidyverse needs to be installed into R despite it being in the container.